### PR TITLE
nodes.py: add start and stop functions

### DIFF
--- a/iotlab_controller/nodes.py
+++ b/iotlab_controller/nodes.py
@@ -80,6 +80,14 @@ class BaseNode(object):
         return iotlabcli.node.node_command(self.api, "reset", exp_id,
                                            [self.uri])
 
+    def start(self, exp_id):
+        return iotlabcli.node.node_command(self.api, "start", exp_id,
+                                           [self.uri])
+
+    def stop(self, exp_id):
+        return iotlabcli.node.node_command(self.api, "stop", exp_id,
+                                           [self.uri])
+
     def profile(self, exp_id, profile):
         return iotlabcli.node.node_command(self.api, "profile", exp_id,
                                            [self.uri], profile)
@@ -218,6 +226,14 @@ class BaseNodes(object):
 
     def reset(self, exp_id):
         return iotlabcli.node.node_command(self.api, "reset", exp_id,
+                                           [n.uri for n in self])
+
+    def start(self, exp_id):
+        return iotlabcli.node.node_command(self.api, "start", exp_id,
+                                           [n.uri for n in self])
+
+    def stop(self, exp_id):
+        return iotlabcli.node.node_command(self.api, "stop", exp_id,
                                            [n.uri for n in self])
 
     def profile(self, exp_id, profile):


### PR DESCRIPTION
allows to power cycle iotlab nodes, right? Not sure though if explicitly calling `start` and `stop` has the same effect as calling `reset`. But anyway, mapping these two should not hurt, right?