### PR TITLE
nodes.py: adapt to iotlabcli API change

### DIFF
--- a/iotlab_controller/nodes.py
+++ b/iotlab_controller/nodes.py
@@ -57,7 +57,7 @@ class BaseNode(object):
 
     @property
     def state(self):
-        nodes = self.api.get_resources(site=self.site,
+        nodes = self.api.get_nodes(site=self.site,
                                        archi=self.arch)["items"]
         for node in nodes:
             if node["network_address"] == self.uri:
@@ -199,7 +199,7 @@ class BaseNodes(object):
             kwargs["state"] = self.state
         if site is not None:
             kwargs["site"] = site
-        return self.api.get_resources(**kwargs)["items"]
+        return self.api.get_nodes(**kwargs)["items"]
 
     def add(self, node):
         """

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 name = "iotlab_controller"
-version = "0.4.1a"
+version = "0.4.2a"
 description = "Python-based controller for IoT-LAB experiments"
 author = "Martine Lenders"
 author_email = "m.lenders@fu-berlin.de"


### PR DESCRIPTION
It seems, that the API of the `iotlabcli` `rest/Api`-class has changed quite some time ago (https://github.com/iot-lab/cli-tools/commit/46f672cae6ff5222566d347b142b997e87915403). AFAIK the `API.get_resources` function was renamed to `API.get_nodes`. This PR adapts the `iotlab_controller` to this change.

Verified with 
```
Name: iotlabcli
Version: 3.2.1
Summary: IoT-LAB testbed command-line client
Home-page: http://www.iot-lab.info
Author: IoT-LAB Team
Author-email: admin@iot-lab.info
License: CeCILL v2.1
Location: /home/hauke/.local/lib/python3.8/site-packages
Requires: requests, jmespath
Required-by: iotlab-controller
```
and the below `iotlab-controller` including this fix:
```
Name: iotlab-controller
Version: 0.4.1a0
Summary: Python-based controller for IoT-LAB experiments
Home-page: https://github.com/miri64/iotlab_controller
Author: Martine Lenders
Author-email: m.lenders@fu-berlin.de
License: UNKNOWN
Location: /home/hauke/.local/lib/python3.8/site-packages
Requires: iotlabcli
Required-by: 
```

