### PR TITLE
nodes.py: adapt to iotlabcli API changes (continued)

### DIFF
--- a/iotlab_controller/nodes.py
+++ b/iotlab_controller/nodes.py
@@ -73,7 +73,7 @@ class BaseNode(object):
                          (self.z - other.z) ** 2)
 
     def flash(self, exp_id, firmware):
-        return iotlabcli.node.node_command(self.api, "update", exp_id,
+        return iotlabcli.node.node_command(self.api, "flash", exp_id,
                                            [self.uri], firmware.path)
 
     def reset(self, exp_id):
@@ -220,7 +220,7 @@ class BaseNodes(object):
         raise NodeError("Can't load node information on {}".format(node))
 
     def flash(self, exp_id, firmware):
-        return iotlabcli.node.node_command(self.api, "update", exp_id,
+        return iotlabcli.node.node_command(self.api, "flash", exp_id,
                                            [n.uri for n in self],
                                            firmware.path)
 
@@ -488,11 +488,11 @@ class SinkNetworkedNodes(NetworkedNodes):
             return super(SinkNetworkedNodes, self).flash(exp_id, firmware)
         else:
             res1 = iotlabcli.node.node_command(
-                    self.api, "update", exp_id, list(self.non_sink_node_uris),
+                    self.api, "flash", exp_id, list(self.non_sink_node_uris),
                     firmware.path
                 )
             res2 = iotlabcli.node.node_command(
-                    self.api, "update", exp_id,
+                    self.api, "flash", exp_id,
                     [common.get_uri(self.site, self.sink)],
                     sink_firmware.path
                 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 name = "iotlab_controller"
-version = "0.4.2a"
+version = "0.4.3a"
 description = "Python-based controller for IoT-LAB experiments"
 author = "Martine Lenders"
 author_email = "m.lenders@fu-berlin.de"


### PR DESCRIPTION
Stumbled upon another one: in https://github.com/iot-lab/cli-tools/commit/46f672cae6ff5222566d347b142b997e87915403 the `update` command was renamed to `flash`. This PR fixes this accordingly. Now my experiment does actually run :-)